### PR TITLE
クラスの依存関係の整理、セッションハイジャック対策

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,3 +8,5 @@ $loader = new ClassLoader();
 $loader->registerDir(dirname(__FILE__) . '');
 
 $loader->register();
+
+\Core\Auth::setUserClass('\Models\User');

--- a/core/Auth.php
+++ b/core/Auth.php
@@ -7,6 +7,15 @@ use models;
 class Auth
 {
 
+    private static $user_class = "";
+
+    // 各アプリで独自のUserクラスを使えるように、利用者からクラス名を設定可能とする
+    // 他メソッドを使う前に必ず設定すること。
+    public static function setUserClass(string $user_class)
+    {
+        self::$user_class = $user_class;
+    }
+
     public static function releaseAuthenticate(): void
     {
         // $_SESSION['user'] = null;
@@ -21,8 +30,8 @@ class Auth
 
     public static function authenticate(string $email, string $password): bool
     {
-
-        $user = new \Models\User();
+        // 本クラスの利用者が事前に設定した
+        $user = new self::$user_class();
 
         //userが見つからなかったらエラーを返す
         if (!$user->fetch($email)) {

--- a/core/Auth.php
+++ b/core/Auth.php
@@ -46,7 +46,10 @@ class Auth
         }
 
         //ログイン処理をする
+        //セッションハイジャックを防ぐため、ログイン時にセッションIDを再生成する
+        session_regenerate_id(true);
         $_SESSION['user'] = $user;
+
         return true;
     }
 


### PR DESCRIPTION
coreからそれ以外へのクラスの依存が生まれていたので解消する
セッションハイジャックを防ぐため、ログイン時にセッションIDを再生成する